### PR TITLE
add missing permissions to docsgen

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -20,5 +20,8 @@ jobs:
   docsgen:
     needs: act
     uses: arcalot/arcaflow-docsgen/.github/workflows/reusable_workflow.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write
     with:
       plugin_path: "arcaflow_plugin_opensearch/opensearch_plugin.py"


### PR DESCRIPTION
## Changes introduced with this PR

Permissions were missing for the docsgen action, causing a CI failure. Permissions fixed.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).