### PR TITLE
Unpin dependencies (revert #59)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -571,4 +571,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "1d1ed9fd3ee7485d2802ad1ee844675afedb28d05fe893bfa3c458c7406a56f7"
+content-hash = "e30a62fa553f0207f367c7c4ffd14c95391a38a5675e95fad7cd802cf9cdb418"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,16 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.12"
-arcaflow-plugin-sdk = "0.14.4"
+arcaflow-plugin-sdk = "^0.14.4"
 opensearch-py = "^3.0.0"
 certifi = "^2025.0.0"
 
 [tool.poetry.dev-dependencies]
-pycodestyle = "2.14.0"
-black = "25.1.0"
-pydocstyle = "6.3.0"
-docformatter = "1.7.7"
-autoflake = "2.3.1"
+pycodestyle = "^2.9.1"
+black = "^25.1.0"
+pydocstyle = "^6.1.1"
+docformatter = "^1.5.0"
+autoflake = "^2.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
## Changes introduced with this PR

This change undoes the effect of #59 (which was over-hastily merged), going back to using `pyproject.toml` to assert the _minimum_ versions of the dependencies (e.g., for development) and relying on the `poetry.lock` file to assert the versions required for installation.
 
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).